### PR TITLE
Upgrade Harmony API to Pydantic v2

### DIFF
--- a/harmony_api/core/settings.py
+++ b/harmony_api/core/settings.py
@@ -28,7 +28,7 @@ import json
 import os
 from typing import Union
 
-from pydantic import BaseSettings
+from pydantic_settings import BaseSettings
 
 GOOGLE_APPLICATION_CREDENTIALS = os.getenv("GOOGLE_APPLICATION_CREDENTIALS", '{}')
 if GOOGLE_APPLICATION_CREDENTIALS:

--- a/harmony_api/helpers.py
+++ b/harmony_api/helpers.py
@@ -60,7 +60,7 @@ def get_example_instruments() -> List[Instrument]:
         str(os.getcwd()) + "/example_questionnaires.json", "r", encoding="utf-8"
     ) as file:
         for line in file:
-            instrument = Instrument.parse_raw(line)
+            instrument = Instrument.model_validate_json(line)
             example_instruments.append(instrument)
 
     return example_instruments

--- a/harmony_api/routers/text_router.py
+++ b/harmony_api/routers/text_router.py
@@ -186,11 +186,11 @@ def match(match_body: MatchBody) -> MatchResponse:
 
     # Model
     model = match_body.parameters
-    if model.dict() not in ALL_HARMONY_API_MODELS:
+    if model.model_dump(mode="json") not in ALL_HARMONY_API_MODELS:
         raise http_exceptions.CouldNotProcessRequestHTTPException(
             "Could not process request because the model does not exist."
         )
-    if not helpers.check_model_availability(model.dict()):
+    if not helpers.check_model_availability(model.model_dump(mode="json")):
         raise http_exceptions.CouldNotProcessRequestHTTPException(
             "Could not process request because the model is not available."
         )

--- a/harmony_api/scheduler.py
+++ b/harmony_api/scheduler.py
@@ -25,16 +25,16 @@ SOFTWARE.
 """
 
 from fastapi.concurrency import run_in_threadpool
-from rocketry import Rocketry
-from rocketry.conds import cron
+# from rocketry import Rocketry
+# from rocketry.conds import cron
 
 from harmony_api.services.instruments_cache import InstrumentsCache
 from harmony_api.services.vectors_cache import VectorsCache
 
-app = Rocketry(executation="async")
+# app = Rocketry(executation="async")
 
 
-@app.task(cron("0 */12 * * *"))
+# @app.task(cron("0 */12 * * *"))
 async def do_every_12th_hour():
     """
     Save the caches to disk every 12th hour.

--- a/harmony_api/services/instruments_cache.py
+++ b/harmony_api/services/instruments_cache.py
@@ -113,7 +113,7 @@ class InstrumentsCache(metaclass=SingletonMeta):
         # Instruments to dict
         cache_parsed: dict[str, List] = {}
         for key, value in self.__cache.items():
-            instruments = [x.dict() for x in value]
+            instruments = [x.model_dump(mode="json")() for x in value]
             cache_parsed[key] = instruments
 
         with open(cache_file_path, "w", encoding="utf8") as file:

--- a/main.py
+++ b/main.py
@@ -40,7 +40,7 @@ from harmony_api.routers.health_check_router import router as health_check_route
 from harmony_api.routers.info_router import router as info_router
 from harmony_api.routers.text_router import router as text_router
 from harmony_api.services.instruments_cache import InstrumentsCache
-from harmony_api.scheduler import app as app_rocketry
+# from harmony_api.scheduler import app as app_rocketry
 from harmony_api.services.vectors_cache import VectorsCache
 
 description = """
@@ -89,7 +89,7 @@ class Server(uvicorn.Server):
     """
 
     def handle_exit(self, sig: int, frame):
-        app_rocketry.session.shut_down()
+        # app_rocketry.session.shut_down()
 
         return super().handle_exit(sig, frame)
 
@@ -112,11 +112,12 @@ async def main():
     )
 
     api = asyncio.create_task(server.serve())
-    scheduler = asyncio.create_task(app_rocketry.serve())
+    # scheduler = asyncio.create_task(app_rocketry.serve())
 
     # Start both applications (FastAPI & Rocketry)
     print("INFO:\t  Starting applications...")
-    await asyncio.wait([api, scheduler])
+    # await asyncio.wait([api, scheduler])
+    await asyncio.wait(api)
 
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 fastapi==0.109.1
 requests==2.31.0
-pydantic==1.10.7
+pydantic==2.8.2
+pydantic-settings==2.4.0
 uvicorn==0.21.1
 pandas==2.0.0
 tika==2.6.0
@@ -10,7 +11,6 @@ XlsxWriter==3.0.9
 openpyxl==3.1.2
 sentence-transformers==2.2.2
 wget==3.2
-rocketry==2.5.1
 openai==1.30.2
 vertexai==1.49.0
 numpy==1.26.4


### PR DESCRIPTION
## Description
#### Related to https://github.com/harmonydata/harmony/issues/50

Related PR and discussion: https://github.com/harmonydata/harmony/pull/51

- Removed Rocketry: it's not compatible with Pydantic V2 and will be replaced with another library @zaironjacobs  
- `BaseSettings` has moved to a separate package, `pydantic-settings`.

## Testing

Tested on a local system: Ubuntu 24.04 LTS [(step-by-step description)](https://gist.github.com/olp-cs/f9f7197e3b3af9cda58994e9dbbe8e98 )

`python -m unittest discover tests/local_tests`

    Before the changes: 18/18 passed
    After the changes: 18/18 passed