### PR TITLE
Fix loading env GOOGLE_APPLICATION_CREDENTIALS

### DIFF
--- a/harmony_api/core/settings.py
+++ b/harmony_api/core/settings.py
@@ -24,60 +24,57 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
-import json
 import os
 from typing import Union
 
+from pydantic import Field
 from pydantic_settings import BaseSettings
-
-GOOGLE_APPLICATION_CREDENTIALS = os.getenv("GOOGLE_APPLICATION_CREDENTIALS", '{}')
-if GOOGLE_APPLICATION_CREDENTIALS:
-    if GOOGLE_APPLICATION_CREDENTIALS.startswith(
-            "{"):  # only load JSON if it's JSON format
-        GOOGLE_APPLICATION_CREDENTIALS = json.loads(GOOGLE_APPLICATION_CREDENTIALS)
 
 
 class Settings(BaseSettings):
     # General harmony_api config
-    VERSION: str = "2.0"
-    APP_TITLE: str = "Harmony API"
-    TIKA_ENDPOINT: str = os.getenv("TIKA_ENDPOINT", "http://tika:9998")
-    OPENAI_API_KEY: str | None = os.getenv("OPENAI_API_KEY")
-    AZURE_OPENAI_API_KEY: str | None = os.getenv("AZURE_OPENAI_API_KEY")
-    AZURE_OPENAI_ENDPOINT: str | None = os.getenv("AZURE_OPENAI_ENDPOINT")
-    AZURE_STORAGE_URL: str | None = os.getenv("AZURE_STORAGE_URL")
-    GOOGLE_APPLICATION_CREDENTIALS: dict = GOOGLE_APPLICATION_CREDENTIALS
+    VERSION: str = Field(description="Application version.", default="2.0")
+    APP_TITLE: str = Field(description="Application title.", default="Harmony API")
+    TIKA_ENDPOINT: str = Field(description="Tika endpoint.", default="http://tika:9998")
+    OPENAI_API_KEY: str | None = Field(description="OpenAI API key.", default=None)
+    AZURE_OPENAI_API_KEY: str | None = Field(description="Azure OpenAI API key.", default=None)
+    AZURE_OPENAI_ENDPOINT: str | None = Field(description="Azure OpenAI endpoint.", default=None)
+    AZURE_STORAGE_URL: str | None = Field(description="Azure Storage URL.", default=None)
+    GOOGLE_APPLICATION_CREDENTIALS: str | None = Field(
+        description="A JSON string is expected here, this is the content of credentials.json.",
+        default=None
+    )
 
 
 class DevSettings(Settings):
-    SERVER_HOST: str = "0.0.0.0"
-    DEBUG: bool = True
-    PORT: int = 8000
-    RELOAD: bool = True
-    CORS: dict = {
+    SERVER_HOST: str = Field(description="Host.", default="0.0.0.0")
+    DEBUG: bool = Field(description="Debug.", default=True)
+    PORT: int = Field(description="Port.", default=8000)
+    RELOAD: bool = Field(description="Reload.", default=True)
+    CORS: dict = Field(description="CORS.", default={
         "origins": [
             "*",
         ],
         "allow_credentials": True,
         "allow_methods": ["*"],
         "allow_headers": ["*"],
-    }
+    })
 
 
 class ProdSettings(Settings):
     # TODO change
-    SERVER_HOST: str = "0.0.0.0"
-    DEBUG: bool = False
-    PORT: int = 8000
-    RELOAD: bool = False
-    CORS: dict = {
+    SERVER_HOST: str = Field(description="Host.", default="0.0.0.0")
+    DEBUG: bool = Field(description="Debug.", default=False)
+    PORT: int = Field(description="Port.", default=8000)
+    RELOAD: bool = Field(description="Reload.", default=False)
+    CORS: dict = Field(description="CORS.", default={
         "origins": [
             "*",
         ],
         "allow_credentials": True,
         "allow_methods": ["*"],
         "allow_headers": ["*"],
-    }
+    })
 
 
 def get_settings() -> Union[DevSettings | ProdSettings]:

--- a/harmony_api/helpers.py
+++ b/harmony_api/helpers.py
@@ -419,7 +419,7 @@ def check_model_availability(model: dict) -> bool:
 
     # Google
     elif model["framework"] == "google":
-        if not settings.GOOGLE_APPLICATION_CREDENTIALS:
+        if not google_embeddings.GOOGLE_APPLICATION_CREDENTIALS_DICT:
             return False
 
         # Check model


### PR DESCRIPTION
## Description

The type for `GOOGLE_APPLICATION_CREDENTIALS` was changed from `dict` to `str | None` in `settings.py`. Previously a crash would occur if the provided value is not a valid JSON or is empty. Now, an attempt to load the env variable as a dictionary is done in `google_embeddings.py` within a try-except block, when this is successful, the Google models will be loaded, else they are not available.

#### Fixes #12

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing

Tested the following to make sure the app does not crash:

- Start app without the env `GOOGLE_APPLICATION_CREDENTIALS`.
- Start app with an invalid JSON at `GOOGLE_APPLICATION_CREDENTIALS`.
- Start app with a valid JSON at `GOOGLE_APPLICATION_CREDENTIALS` where the content does not contain the keys expected (the expected content is the content of `credentials.json`).
